### PR TITLE
simple shadow map stabilization during movement

### DIFF
--- a/TESReloaded/Core/ShadowManager.cpp
+++ b/TESReloaded/Core/ShadowManager.cpp
@@ -511,9 +511,14 @@ void ShadowManager::RenderShadowMaps() {
 		NiNode* PlayerNode = Player->GetNode();
 		D3DXVECTOR3 At;
 
-		At.x = PlayerNode->m_worldTransform.pos.x - TheRenderManager->CameraPosition.x;
-		At.y = PlayerNode->m_worldTransform.pos.y - TheRenderManager->CameraPosition.y;
-		At.z = PlayerNode->m_worldTransform.pos.z - TheRenderManager->CameraPosition.z;
+		At.x = LookAtPosition.x - TheRenderManager->CameraPosition.x;
+		At.y = LookAtPosition.y - TheRenderManager->CameraPosition.y;
+		At.z = LookAtPosition.z - TheRenderManager->CameraPosition.z;
+		D3DXVECTOR3 newPos(PlayerNode->m_worldTransform.pos.x, PlayerNode->m_worldTransform.pos.y, PlayerNode->m_worldTransform.pos.z);
+
+		if (D3DXVec3Length(&(newPos - LookAtPosition)) > ShadowsExteriors->ShadowMapRadius[MapNear] / 2.0f) {
+			LookAtPosition = newPos;
+		}
 
 		CurrentVertex = ShadowMapVertex;
 		CurrentPixel = ShadowMapPixel;

--- a/TESReloaded/Core/ShadowManager.h
+++ b/TESReloaded/Core/ShadowManager.h
@@ -38,5 +38,6 @@ public:
 	NiPointLight*			ShadowCubeMapLights[4];
 	ShaderRecordVertex*		CurrentVertex;
 	ShaderRecordPixel*		CurrentPixel;
+	D3DXVECTOR3				LookAtPosition;
 	bool					AlphaEnabled;
 };


### PR DESCRIPTION
essentially only updates the shadow map location after player has moved a "significant" amount 