### PR TITLE
Esm shadows

### DIFF
--- a/Extra/Shaders/NewVegasReloaded/Shaders/Shadows/ShadowMapBlur.pso.hlsl
+++ b/Extra/Shaders/NewVegasReloaded/Shaders/Shadows/ShadowMapBlur.pso.hlsl
@@ -1,4 +1,5 @@
 float4 TESR_ReciprocalResolution  : register(c0);
+float4 TESR_BlurDirection  : register(c1);
 sampler2D SourceBuffer : register(s0) = sampler_state { ADDRESSU = CLAMP; ADDRESSV = CLAMP; MAGFILTER = LINEAR; MINFILTER = LINEAR; MIPFILTER = LINEAR; };
 
 struct VSOUT
@@ -7,20 +8,37 @@ struct VSOUT
 	float2 UVCoord : TEXCOORD0;
 };
 
+
 // adapted from https://github.com/Jam3/glsl-fast-gaussian-blur
-float4 blur9(sampler2D image, float2 uv, float2 resolution, float2 direction) {
+float4 blur9(sampler2D image, float2 uv, float2 direction) {
   float4 color = float4(0.0, 0.0, 0.0, 1.0);
-  float2 off1 = float2(1.3846153846, 1.3846153846) * direction * resolution;
-  float2 off2 = float2(3.2307692308, 3.2307692308) * direction * resolution;
-  color += tex2D(image, uv) * 0.2270270270;
-  color += tex2D(image, uv + (off1)) * 0.3162162162;
-  color += tex2D(image, uv - (off1)) * 0.3162162162;
-  color += tex2D(image, uv + (off2)) * 0.0702702703;
-  color += tex2D(image, uv - (off2)) * 0.0702702703;
+
+  float weights[5] = {
+    0.2270270270,
+    0.3162162162,
+    0.3162162162,
+    0.0702702703,
+    0.0702702703,
+  };
+
+  // precalculate sampling offsets to use linear filtering
+  float off1 = 1.3846153846;
+  float off2 = 3.2307692308;
+  float2 offsets[5];
+  offsets[0] = float2(0.0f, 0.0f);
+  offsets[1] = float2(off1, off1) * direction * TESR_ReciprocalResolution.xx;
+  offsets[2] = float2(-off1, -off1) * direction * TESR_ReciprocalResolution.xx;
+  offsets[3] = float2(off2, off2) * direction * TESR_ReciprocalResolution.xx;
+  offsets[4] = float2(-off2, -off2) * direction * TESR_ReciprocalResolution.xx;
+
+  for (int i=0; i<5; i++){
+    color += tex2D(image, uv + offsets[i]) * weights[i];
+  }
+
   return color;
 }
 
 float4 main(VSOUT IN) : COLOR0
 {
-	return blur9(SourceBuffer, IN.UVCoord, TESR_ReciprocalResolution.xx, float2(1.0, 1.0));
+	return blur9(SourceBuffer, IN.UVCoord, TESR_BlurDirection.xy);
 }

--- a/TESReloaded/Core/TextureManager.cpp
+++ b/TESReloaded/Core/TextureManager.cpp
@@ -115,12 +115,14 @@ void TextureManager::Initialize() {
 	for (int i = 0; i < 5; i++) {
 		// create one texture per ShadowMap type
 		ShadowMapSize = ShadowsExteriors->ShadowMapSize[i];
-		Device->CreateTexture(ShadowMapSize, ShadowMapSize, 1, D3DUSAGE_RENDERTARGET, D3DFMT_G32R32F, D3DPOOL_DEFAULT, &TheTextureManager->ShadowMapTexture[i], NULL);
+		Device->CreateTexture(ShadowMapSize, ShadowMapSize, 1, D3DUSAGE_RENDERTARGET, D3DFMT_R32F, D3DPOOL_DEFAULT, &TheTextureManager->ShadowMapTexture[i], NULL);
 		TheTextureManager->ShadowMapTexture[i]->GetSurfaceLevel(0, &TheTextureManager->ShadowMapSurface[i]);
 		Device->CreateDepthStencilSurface(ShadowMapSize, ShadowMapSize, D3DFMT_D24S8, D3DMULTISAMPLE_NONE, 0, true, &TheTextureManager->ShadowMapDepthSurface[i], NULL);
-        if (i < 4){ //Don't blur orthomap
-            Device->CreateTexture(ShadowMapSize, ShadowMapSize, 1, D3DUSAGE_RENDERTARGET, D3DFMT_G32R32F, D3DPOOL_DEFAULT, &TheTextureManager->ShadowMapTextureBlurred[i], NULL);
-            TheTextureManager->ShadowMapTextureBlurred[i]->GetSurfaceLevel(0, &TheTextureManager->ShadowMapSurfaceBlurred[i]);
+        if (i != TheShadowManager->ShadowMapTypeEnum::MapOrtho){ //Don't blur orthomap
+            // create a texture to receive the surface contents
+			Device->CreateTexture(ShadowMapSize, ShadowMapSize, 1, D3DUSAGE_RENDERTARGET, D3DFMT_R32F, D3DPOOL_DEFAULT, &TheTextureManager->ShadowMapTextureBlurred[i], NULL);
+            // set the surface level to the texture.
+			TheTextureManager->ShadowMapTextureBlurred[i]->GetSurfaceLevel(0, &TheTextureManager->ShadowMapSurfaceBlurred[i]);
         }
     }
 	for (int i = 0; i < ShadowCubeMapsMax; i++) {


### PR DESCRIPTION
Switches shadows algorithm from VSM to ESM shadows (more stable, less light bleeding, lighter (one channel in shadow map), supports filtering/blurring the shadow map.

Also refactors some magic numbers to use enum values, streamlines the blurring passes of the shadow map into two passes.