### PR TITLE
Calculate cascades

### DIFF
--- a/Extra/NewVegasReloaded.dll.config
+++ b/Extra/NewVegasReloaded.dll.config
@@ -371,12 +371,14 @@
 			<PostProcess Value="1" Type="0" Reboot="0" Info="" />
 		</Status>
 		<Main>
-			<Darkness Value="0.2" Type="2" Reboot="0" Info="" />
+			<Enabled Value="1" Type="0" Reboot="0" Info="" />
+			<Darkness Value="0.4" Type="2" Reboot="0" Info="" />
 			<Quality Value="2" Type="1" Reboot="0" Info="" />
-			<ShadowMapFarPlane Value="16000.0" Type="2" Reboot="0" Info="" />
+			<ShadowsRadius Value="12000" Type="2" Reboot="0" Info="" />
+			<ShadowMapResolution Value="1024" Type="2" Reboot="0" Info="" />
+			<ShadowMapFarPlane Value="32768" Type="2" Reboot="0" Info="" />
 		</Main>
 		<Near>
-			<Enabled Value="1" Type="0" Reboot="0" Info="" />
 			<AlphaEnabled Value="1" Type="0" Reboot="0" Info="" />
 			<Activators Value="0" Type="0" Reboot="0" Info="" />
 			<Actors Value="1" Type="0" Reboot="0" Info="" />
@@ -390,8 +392,6 @@
 			<Terrain Value="1" Type="0" Reboot="0" Info="" />
 			<Trees Value="1" Type="0" Reboot="0" Info="" />
 			<MinRadius Value="10.0" Type="2" Reboot="0" Info="" />
-			<ShadowMapSize Value="2048.0" Type="1" Reboot="0" Info="" />
-			<ShadowMapRadius Value="1024.0" Type="2" Reboot="0" Info="" />
 		</Near>
 		<Middle>
 			<AlphaEnabled Value="1" Type="0" Reboot="0" Info="" />
@@ -407,8 +407,6 @@
 			<Terrain Value="1" Type="0" Reboot="0" Info="" />
 			<Trees Value="1" Type="0" Reboot="0" Info="" />
 			<MinRadius Value="10.0" Type="2" Reboot="0" Info="" />
-			<ShadowMapSize Value="2048.0" Type="1" Reboot="0" Info="" />
-			<ShadowMapRadius Value="4096.0" Type="2" Reboot="0" Info="" />
 		</Middle>
 		<Far>
 			<AlphaEnabled Value="1" Type="0" Reboot="0" Info="" />
@@ -424,8 +422,6 @@
 			<Terrain Value="1" Type="0" Reboot="0" Info="" />
 			<Trees Value="1" Type="0" Reboot="0" Info="" />
 			<MinRadius Value="10.0" Type="2" Reboot="0" Info="" />
-			<ShadowMapSize Value="2048.0" Type="1" Reboot="0" Info="" />
-			<ShadowMapRadius Value="8192.0" Type="2" Reboot="0" Info="" />
 		</Far>
 		<Lod>
 			<AlphaEnabled Value="0" Type="0" Reboot="0" Info="" />
@@ -441,8 +437,6 @@
 			<Terrain Value="1" Type="0" Reboot="0" Info="" />
 			<Trees Value="1" Type="0" Reboot="0" Info="" />
 			<MinRadius Value="100.0" Type="2" Reboot="0" Info="" />
-			<ShadowMapSize Value="2048.0" Type="1" Reboot="0" Info="" />
-			<ShadowMapRadius Value="20000.0" Type="2" Reboot="0" Info="" />
 		</Lod>
 		<Ortho>
 			<AlphaEnabled Value="1" Type="0" Reboot="0" Info="" />
@@ -458,8 +452,6 @@
 			<Terrain Value="1" Type="0" Reboot="0" Info="" />
 			<Trees Value="0" Type="0" Reboot="0" Info="" />
 			<MinRadius Value="100.0" Type="2" Reboot="0" Info="" />
-			<ShadowMapSize Value="1024" Type="1" Reboot="0" Info="" />
-			<ShadowMapRadius Value="1024.0" Type="2" Reboot="0" Info="" />
 		</Ortho>
 		<ExcludedFormID>
 		</ExcludedFormID>

--- a/TESReloaded/Core/SettingManager.cpp
+++ b/TESReloaded/Core/SettingManager.cpp
@@ -751,8 +751,14 @@ void SettingManager::LoadSettings() {
 	SettingsPrecipitations.SnowAccumulation.BlurNormDropThreshhold = GetSettingF("Shaders.Precipitations.SnowAccumulation", "BlurNormDropThreshhold");
 	SettingsPrecipitations.SnowAccumulation.BlurRadiusMultiplier = GetSettingF("Shaders.Precipitations.SnowAccumulation", "BlurRadiusMultiplier");
 
+	// Generic exterior shadows settings
+	SettingsShadows.Exteriors.Enabled = GetSettingI("Shaders.ShadowsExteriors.Main", "Enabled");
+	SettingsShadows.Exteriors.Quality = GetSettingI("Shaders.ShadowsExteriors.Main", "Quality");
+	SettingsShadows.Exteriors.Darkness = GetSettingF("Shaders.ShadowsExteriors.Main", "Darkness");
+	SettingsShadows.Exteriors.ShadowRadius = GetSettingF("Shaders.ShadowsExteriors.Main", "ShadowsRadius");
+	SettingsShadows.Exteriors.ShadowMapResolution = GetSettingI("Shaders.ShadowsExteriors.Main", "ShadowMapResolution");
+	SettingsShadows.Exteriors.ShadowMapFarPlane = GetSettingF("Shaders.ShadowsExteriors.Main", "ShadowMapFarPlane");
 
-	SettingsShadows.Exteriors.Enabled = GetSettingI("Shaders.ShadowsExteriors.Near", "Enabled");
 	SettingsShadows.Exteriors.AlphaEnabled[ShadowManager::ShadowMapTypeEnum::MapNear] = GetSettingI("Shaders.ShadowsExteriors.Near", "AlphaEnabled");
 	SettingsShadows.Exteriors.Forms[ShadowManager::ShadowMapTypeEnum::MapNear].Activators = GetSettingI("Shaders.ShadowsExteriors.Near", "Activators");
 	SettingsShadows.Exteriors.Forms[ShadowManager::ShadowMapTypeEnum::MapNear].Actors = GetSettingI("Shaders.ShadowsExteriors.Near", "Actors");
@@ -765,10 +771,7 @@ void SettingManager::LoadSettings() {
 	SettingsShadows.Exteriors.Forms[ShadowManager::ShadowMapTypeEnum::MapNear].Statics = GetSettingI("Shaders.ShadowsExteriors.Near", "Statics");
 	SettingsShadows.Exteriors.Forms[ShadowManager::ShadowMapTypeEnum::MapNear].Terrain = GetSettingI("Shaders.ShadowsExteriors.Near", "Terrain");
 	SettingsShadows.Exteriors.Forms[ShadowManager::ShadowMapTypeEnum::MapNear].Trees = GetSettingI("Shaders.ShadowsExteriors.Near", "Trees");
-	SettingsShadows.Exteriors.Forms[ShadowManager::ShadowMapTypeEnum::MapNear].MinRadius = GetSettingF("Shaders.ShadowsExteriors.Near", "MinRadius");
-	SettingsShadows.Exteriors.ShadowMapSize[ShadowManager::ShadowMapTypeEnum::MapNear] = GetSettingI("Shaders.ShadowsExteriors.Near", "ShadowMapSize");
-	SettingsShadows.Exteriors.ShadowMapRadius[ShadowManager::ShadowMapTypeEnum::MapNear] = GetSettingF("Shaders.ShadowsExteriors.Near", "ShadowMapRadius");
-
+	
 	SettingsShadows.Exteriors.AlphaEnabled[ShadowManager::ShadowMapTypeEnum::MapMiddle] = GetSettingI("Shaders.ShadowsExteriors.Middle", "AlphaEnabled");
 	SettingsShadows.Exteriors.Forms[ShadowManager::ShadowMapTypeEnum::MapMiddle].Activators = GetSettingI("Shaders.ShadowsExteriors.Middle", "Activators");
 	SettingsShadows.Exteriors.Forms[ShadowManager::ShadowMapTypeEnum::MapMiddle].Actors = GetSettingI("Shaders.ShadowsExteriors.Middle", "Actors");
@@ -781,10 +784,7 @@ void SettingManager::LoadSettings() {
 	SettingsShadows.Exteriors.Forms[ShadowManager::ShadowMapTypeEnum::MapMiddle].Statics = GetSettingI("Shaders.ShadowsExteriors.Middle", "Statics");
 	SettingsShadows.Exteriors.Forms[ShadowManager::ShadowMapTypeEnum::MapMiddle].Terrain = GetSettingI("Shaders.ShadowsExteriors.Middle", "Terrain");
 	SettingsShadows.Exteriors.Forms[ShadowManager::ShadowMapTypeEnum::MapMiddle].Trees = GetSettingI("Shaders.ShadowsExteriors.Middle", "Trees");
-	SettingsShadows.Exteriors.Forms[ShadowManager::ShadowMapTypeEnum::MapMiddle].MinRadius = GetSettingF("Shaders.ShadowsExteriors.Middle", "MinRadius");
-	SettingsShadows.Exteriors.ShadowMapSize[ShadowManager::ShadowMapTypeEnum::MapMiddle] = GetSettingI("Shaders.ShadowsExteriors.Middle", "ShadowMapSize");
-	SettingsShadows.Exteriors.ShadowMapRadius[ShadowManager::ShadowMapTypeEnum::MapMiddle] = GetSettingF("Shaders.ShadowsExteriors.Middle", "ShadowMapRadius");
-
+	
 	SettingsShadows.Exteriors.AlphaEnabled[ShadowManager::ShadowMapTypeEnum::MapFar] = GetSettingI("Shaders.ShadowsExteriors.Far", "AlphaEnabled");
 	SettingsShadows.Exteriors.Forms[ShadowManager::ShadowMapTypeEnum::MapFar].Activators = GetSettingI("Shaders.ShadowsExteriors.Far", "Activators");
 	SettingsShadows.Exteriors.Forms[ShadowManager::ShadowMapTypeEnum::MapFar].Actors = GetSettingI("Shaders.ShadowsExteriors.Far", "Actors");
@@ -797,10 +797,7 @@ void SettingManager::LoadSettings() {
 	SettingsShadows.Exteriors.Forms[ShadowManager::ShadowMapTypeEnum::MapFar].Statics = GetSettingI("Shaders.ShadowsExteriors.Far", "Statics");
 	SettingsShadows.Exteriors.Forms[ShadowManager::ShadowMapTypeEnum::MapFar].Terrain = GetSettingI("Shaders.ShadowsExteriors.Far", "Terrain");
 	SettingsShadows.Exteriors.Forms[ShadowManager::ShadowMapTypeEnum::MapFar].Trees = GetSettingI("Shaders.ShadowsExteriors.Far", "Trees");
-	SettingsShadows.Exteriors.Forms[ShadowManager::ShadowMapTypeEnum::MapFar].MinRadius = GetSettingF("Shaders.ShadowsExteriors.Far", "MinRadius");
-	SettingsShadows.Exteriors.ShadowMapSize[ShadowManager::ShadowMapTypeEnum::MapFar] = GetSettingI("Shaders.ShadowsExteriors.Far", "ShadowMapSize");
-	SettingsShadows.Exteriors.ShadowMapRadius[ShadowManager::ShadowMapTypeEnum::MapFar] = GetSettingF("Shaders.ShadowsExteriors.Far", "ShadowMapRadius");
-
+	
 	SettingsShadows.Exteriors.AlphaEnabled[ShadowManager::ShadowMapTypeEnum::MapLod] = GetSettingI("Shaders.ShadowsExteriors.Lod", "AlphaEnabled");
 	SettingsShadows.Exteriors.Forms[ShadowManager::ShadowMapTypeEnum::MapLod].Activators = GetSettingI("Shaders.ShadowsExteriors.Lod", "Activators");
 	SettingsShadows.Exteriors.Forms[ShadowManager::ShadowMapTypeEnum::MapLod].Actors = GetSettingI("Shaders.ShadowsExteriors.Lod", "Actors");
@@ -813,10 +810,7 @@ void SettingManager::LoadSettings() {
 	SettingsShadows.Exteriors.Forms[ShadowManager::ShadowMapTypeEnum::MapLod].Statics = GetSettingI("Shaders.ShadowsExteriors.Lod", "Statics");
 	SettingsShadows.Exteriors.Forms[ShadowManager::ShadowMapTypeEnum::MapLod].Terrain = GetSettingI("Shaders.ShadowsExteriors.Lod", "Terrain");
 	SettingsShadows.Exteriors.Forms[ShadowManager::ShadowMapTypeEnum::MapLod].Trees = GetSettingI("Shaders.ShadowsExteriors.Lod", "Trees");
-	SettingsShadows.Exteriors.Forms[ShadowManager::ShadowMapTypeEnum::MapLod].MinRadius = GetSettingF("Shaders.ShadowsExteriors.Lod", "MinRadius");
-	SettingsShadows.Exteriors.ShadowMapSize[ShadowManager::ShadowMapTypeEnum::MapLod] = GetSettingI("Shaders.ShadowsExteriors.Lod", "ShadowMapSize");
-	SettingsShadows.Exteriors.ShadowMapRadius[ShadowManager::ShadowMapTypeEnum::MapLod] = GetSettingF("Shaders.ShadowsExteriors.Lod", "ShadowMapRadius");
-
+	
 	SettingsShadows.Exteriors.AlphaEnabled[ShadowManager::ShadowMapTypeEnum::MapOrtho] = GetSettingI("Shaders.ShadowsExteriors.Ortho", "AlphaEnabled");
 	SettingsShadows.Exteriors.Forms[ShadowManager::ShadowMapTypeEnum::MapOrtho].Activators = GetSettingI("Shaders.ShadowsExteriors.Ortho", "Activators");
 	SettingsShadows.Exteriors.Forms[ShadowManager::ShadowMapTypeEnum::MapOrtho].Actors = GetSettingI("Shaders.ShadowsExteriors.Ortho", "Actors");
@@ -829,13 +823,7 @@ void SettingManager::LoadSettings() {
 	SettingsShadows.Exteriors.Forms[ShadowManager::ShadowMapTypeEnum::MapOrtho].Statics = GetSettingI("Shaders.ShadowsExteriors.Ortho", "Statics");
 	SettingsShadows.Exteriors.Forms[ShadowManager::ShadowMapTypeEnum::MapOrtho].Terrain = GetSettingI("Shaders.ShadowsExteriors.Ortho", "Terrain");
 	SettingsShadows.Exteriors.Forms[ShadowManager::ShadowMapTypeEnum::MapOrtho].Trees = GetSettingI("Shaders.ShadowsExteriors.Ortho", "Trees");
-	SettingsShadows.Exteriors.Forms[ShadowManager::ShadowMapTypeEnum::MapOrtho].MinRadius = GetSettingF("Shaders.ShadowsExteriors.Ortho", "MinRadius");
-	SettingsShadows.Exteriors.ShadowMapSize[ShadowManager::ShadowMapTypeEnum::MapOrtho] = GetSettingI("Shaders.ShadowsExteriors.Ortho", "ShadowMapSize");
-	SettingsShadows.Exteriors.ShadowMapRadius[ShadowManager::ShadowMapTypeEnum::MapOrtho] = GetSettingF("Shaders.ShadowsExteriors.Ortho", "ShadowMapRadius");
-	SettingsShadows.Exteriors.Quality = GetSettingI("Shaders.ShadowsExteriors.Main", "Quality");
-	SettingsShadows.Exteriors.Darkness = GetSettingF("Shaders.ShadowsExteriors.Main", "Darkness");
-	SettingsShadows.Exteriors.ShadowMapFarPlane = GetSettingF("Shaders.ShadowsExteriors.Main", "ShadowMapFarPlane");
-
+	
 	Config.FillSections(&List, "Shaders.ShadowsExteriors.ExcludedFormID");
 	if (List.size()) SettingsShadows.Exteriors.ExcludedForms.reserve(List.size());
 	for (StringList::iterator Iter = List.begin(); Iter != List.end(); ++Iter) {

--- a/TESReloaded/Core/SettingManager.h
+++ b/TESReloaded/Core/SettingManager.h
@@ -269,7 +269,8 @@ struct SettingsShadowStruct {
 		FormsStruct			Forms[5];
 		bool				AlphaEnabled[5];
 		int					Quality;
-		int					ShadowMapSize[5];
+		int					ShadowMapResolution;
+		float				ShadowRadius;
 		float				Darkness;
 		float				ShadowMapRadius[5];
 		float				ShadowMapFarPlane;

--- a/TESReloaded/Core/ShadowManager.h
+++ b/TESReloaded/Core/ShadowManager.h
@@ -35,6 +35,8 @@ public:
 	void					CalculateBlend(NiPointLight** Lights, int LightIndex);
     void                    BlurShadowMap(ShadowMapTypeEnum ShadowMapType);    
 	D3DXMATRIX				GetCascadeViewProj(ShadowMapTypeEnum ShadowMapType, SettingsShadowStruct::ExteriorsStruct* ShadowsExteriors, D3DXMATRIX View);
+	static void				GetCascadeDepths();
+	static float			lerp(float a, float b, float t);
 
     ShaderRecordVertex*		ShadowMapVertex;
 	ShaderRecordPixel*		ShadowMapPixel;
@@ -45,6 +47,8 @@ public:
 	ShaderRecordVertex*		ShadowCubeMapVertex;
 	ShaderRecordPixel*		ShadowCubeMapPixel;
     
+	float					ShadowCascadesDepth[3];
+
     ShaderRecordVertex*		ShadowMapBlurVertex;
 	ShaderRecordPixel*		ShadowMapBlurPixel;
     IDirect3DVertexBuffer9* BlurShadowVertex[4];

--- a/TESReloaded/Core/TextureManager.cpp
+++ b/TESReloaded/Core/TextureManager.cpp
@@ -112,9 +112,11 @@ void TextureManager::Initialize() {
 	TheTextureManager->SourceTexture->GetSurfaceLevel(0, &TheTextureManager->SourceSurface);
 	TheTextureManager->RenderedTexture->GetSurfaceLevel(0, &TheTextureManager->RenderedSurface);
 	Device->CreateTexture(Width, Height, 1, D3DUSAGE_DEPTHSTENCIL, (D3DFORMAT)MAKEFOURCC('I', 'N', 'T', 'Z'), D3DPOOL_DEFAULT, &TheTextureManager->DepthTexture, NULL);
+
 	for (int i = 0; i < 5; i++) {
 		// create one texture per ShadowMap type
-		ShadowMapSize = ShadowsExteriors->ShadowMapSize[i];
+		ShadowMapSize = ShadowsExteriors->ShadowMapResolution;
+
 		Device->CreateTexture(ShadowMapSize, ShadowMapSize, 1, D3DUSAGE_RENDERTARGET, D3DFMT_R32F, D3DPOOL_DEFAULT, &TheTextureManager->ShadowMapTexture[i], NULL);
 		TheTextureManager->ShadowMapTexture[i]->GetSurfaceLevel(0, &TheTextureManager->ShadowMapSurface[i]);
 		Device->CreateDepthStencilSurface(ShadowMapSize, ShadowMapSize, D3DFMT_D24S8, D3DMULTISAMPLE_NONE, 0, true, &TheTextureManager->ShadowMapDepthSurface[i], NULL);


### PR DESCRIPTION
refactored settings to use a general shadow map resolution/far distance settings.
Intermediary cascade depths are calculated automatically, and all use the same map resolution.

closes #28 