### PR TITLE
add github action to build/deploy each project on tag

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,67 @@
+name: deployTemplate
+
+on:
+  workflow_call:
+    inputs:
+      projectname:
+        required: true
+        type: string
+
+env:
+  # Path to the solution file relative to the root of the project.
+  SOLUTION_FILE_PATH: .
+
+  # Configuration type to build.
+  # You can convert this to a build matrix if you need coverage of multiple configuration types.
+  # https://docs.github.com/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
+  BUILD_CONFIGURATION: Release
+  VERSION: ${{github.ref_name}}
+  ARTEFACT_NAME: ${{inputs.projectname}}-${{github.ref_name}}
+
+jobs:
+  build:
+    runs-on: windows-2019
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Add MSBuild to PATH
+      uses: microsoft/setup-msbuild@v1.0.2
+
+    - name: Restore NuGet packages
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      run: nuget restore ${{env.SOLUTION_FILE_PATH}}
+
+    - name: Build
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      # Add additional options to the MSBuild command line here (like platform or verbosity level).
+      # See https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference
+      run: cmd /c build.bat ${{inputs.projectname}}
+
+    - name: zip files
+      uses: vimtor/action-zip@v1
+      with:
+        files: build/${{inputs.projectname}}/
+        dest: ${{env.ARTEFACT_NAME}}.zip
+
+    - name: Create Release
+      uses: actions/create-release@v1
+      id: create_release
+      with:
+        draft: false
+        prerelease: false
+        release_name: ${{env.ARTEFACT_NAME}}
+        tag_name: release-${{env.VERSION}}
+        # body_path: CHANGELOG.md #TODO: add changelog
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+
+    - name: Upload Release Artifact
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ./${{env.ARTEFACT_NAME}}.zip
+        asset_name: ${{env.ARTEFACT_NAME}}.zip
+        asset_content_type: application/zip

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,22 @@
+name: deploy
+
+on:
+  push:
+    branches: [master]
+    tags:
+     - '*'
+
+jobs:
+  NVRdeploy:
+    name: NVRdeploy
+    if: github.ref_type == 'tag' && contains(github.ref_name, 'NVR')
+    uses: ./.github/workflows/deploy.yml
+    with:
+      projectname: "NewVegasReloaded"
+
+  ORdeploy:
+    name: ORdeploy
+    if: github.ref_type == 'tag' && contains(github.ref_name, 'OR')
+    uses: ./.github/workflows/deploy.yml
+    with:
+      projectname: "OblivionReloaded"

--- a/build.bat
+++ b/build.bat
@@ -14,7 +14,7 @@ if "%PROJECT%" NEQ "NewVegasReloaded" (
 )
 
 @REM build project
-"%programfiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin\msbuild" -target:%PROJECT% /property:Configuration=Release /property:Platform=x86 -m
+msbuild -target:%PROJECT% /property:Configuration=Release /property:Platform=x86 -m
 
 if %ERRORLEVEL% NEQ 0 (
     echo Build has failed. Deploy aborted.


### PR DESCRIPTION
This PR adds a build/release/deploy action to the repo.

It works like this: tag a commit with NVR + version (ex: NVR4.0.0beta1) to build the plugin (dll + config/shaders etc), create a release with the name of the tag, and attaches the built files to it.

Tags that start with NVR will build NewVegasReloaded, and tags with OR will build Oblivion. Any other tag will not build anything.