### PR TITLE
Shadow attenuation

### DIFF
--- a/Extra/NewVegasReloaded.dll.config
+++ b/Extra/NewVegasReloaded.dll.config
@@ -399,6 +399,11 @@
 			<ShadowMapResolution Value="1024" Type="2" Reboot="0" Info="" />
 			<ShadowMapFarPlane Value="32768" Type="2" Reboot="0" Info="" />
 		</Main>
+		<ScreenSpace>
+			<Enabled Value="1" Type="0" Reboot="0" Info="" />
+			<BlurRadius Value="1" Type="2" Reboot="0" Info="" />
+			<RenderDistance Value="5000" Type="1" Reboot="0" Info="" />
+		</ScreenSpace>
 		<Near>
 			<AlphaEnabled Value="1" Type="0" Reboot="0" Info="" />
 			<Activators Value="0" Type="0" Reboot="0" Info="" />

--- a/Extra/Shaders/NewVegasReloaded/Effects/AmbientOcclusion.fx.hlsl
+++ b/Extra/Shaders/NewVegasReloaded/Effects/AmbientOcclusion.fx.hlsl
@@ -2,13 +2,9 @@
 
 #define viewao 0
 
-float4x4 TESR_ProjectionTransform;
-float4x4 TESR_InvProjectionTransform;
-float4 TESR_ReciprocalResolution;
 float4 TESR_AmbientOcclusionAOData;
 float4 TESR_AmbientOcclusionData;
-float4 TESR_DepthConstants;
-float4 TESR_CameraData;
+float4 TESR_ReciprocalResolution;
 float4 TESR_FogDistance; // x: fog start, y: fog end, z: weather percentage, w: sun glare
 float4 TESR_FogColor;
 
@@ -17,58 +13,16 @@ sampler2D TESR_DepthBuffer : register(s1) = sampler_state { ADDRESSU = CLAMP; AD
 sampler2D TESR_SourceBuffer : register(s2) = sampler_state { ADDRESSU = CLAMP; ADDRESSV = CLAMP; MAGFILTER = LINEAR; MINFILTER = LINEAR; MIPFILTER = LINEAR; };
 sampler2D TESR_NoiseSampler : register(s3) < string ResourceName = "Effects\noise.dds"; > = sampler_state { ADDRESSU = WRAP; ADDRESSV = WRAP; MAGFILTER = NONE; MINFILTER = NONE; MIPFILTER = NONE; };
 
-static const float nearZ = TESR_CameraData.x;
-static const float farZ = TESR_CameraData.y;
-static const float aspectRatio = TESR_CameraData.z;
-static const float fov = TESR_CameraData.w;
-static const float depthRange = farZ - nearZ;
-static const float halfFOV = radians(fov*0.5);
-static const float Q = farZ/(farZ - nearZ);
-
 static const float AOsamples = TESR_AmbientOcclusionAOData.x;
 static const float AOstrength = TESR_AmbientOcclusionAOData.y;
 static const float AOclamp = TESR_AmbientOcclusionAOData.z;
 static const float AOrange = TESR_AmbientOcclusionAOData.w;
 static const float AOangleBias = TESR_AmbientOcclusionData.x;
 static const float AOlumThreshold = TESR_AmbientOcclusionData.y;
-static const float AOblurDrop = TESR_AmbientOcclusionData.z;
-static const float AOblurRadius = TESR_AmbientOcclusionData.w;
-static const float2 texelSize = float2(TESR_ReciprocalResolution.x, TESR_ReciprocalResolution.y);
-static const int cKernelSize = 12;
+static const float blurDrop = TESR_AmbientOcclusionData.z;
+static const float blurRadius = TESR_AmbientOcclusionData.w;
 static const int startFade = 2000;
 static const int endFade = 8000;
-
-static const float BlurWeights[cKernelSize] = 
-{
-	0.057424882f,
-	0.058107773f,
-	0.061460144f,
-	0.071020611f,
-	0.088092873f,
-	0.106530916f,
-	0.106530916f,
-	0.088092873f,
-	0.071020611f,
-	0.061460144f,
-	0.058107773f,
-	0.057424882f
-};
- 
-static const float2 BlurOffsets[cKernelSize] = 
-{
-	float2(-6.0f * TESR_ReciprocalResolution.x, -6.0f * TESR_ReciprocalResolution.y),
-	float2(-5.0f * TESR_ReciprocalResolution.x, -5.0f * TESR_ReciprocalResolution.y),
-	float2(-4.0f * TESR_ReciprocalResolution.x, -4.0f * TESR_ReciprocalResolution.y),
-	float2(-3.0f * TESR_ReciprocalResolution.x, -3.0f * TESR_ReciprocalResolution.y),
-	float2(-2.0f * TESR_ReciprocalResolution.x, -2.0f * TESR_ReciprocalResolution.y),
-	float2(-1.0f * TESR_ReciprocalResolution.x, -1.0f * TESR_ReciprocalResolution.y),
-	float2( 1.0f * TESR_ReciprocalResolution.x,  1.0f * TESR_ReciprocalResolution.y),
-	float2( 2.0f * TESR_ReciprocalResolution.x,  2.0f * TESR_ReciprocalResolution.y),
-	float2( 3.0f * TESR_ReciprocalResolution.x,  3.0f * TESR_ReciprocalResolution.y),
-	float2( 4.0f * TESR_ReciprocalResolution.x,  4.0f * TESR_ReciprocalResolution.y),
-	float2( 5.0f * TESR_ReciprocalResolution.x,  5.0f * TESR_ReciprocalResolution.y),
-	float2( 6.0f * TESR_ReciprocalResolution.x,  6.0f * TESR_ReciprocalResolution.y)
-};
  
 struct VSOUT
 {
@@ -90,97 +44,21 @@ VSOUT FrameVS(VSIN IN)
 	return OUT;
 }
  
+#include "Includes/Depth.hlsl"
+#include "Includes/Blur.hlsl"
 
 // returns a semi random float3 between 0 and 1 based on the given seed.
 // tailored to return a different value for each uv coord of the screen.
 float3 random(float2 seed)
 {
-	return tex2D(TESR_NoiseSampler, (seed/255 + 0.5) / texelSize).xyz;
+	return tex2D(TESR_NoiseSampler, (seed/255 + 0.5) / TESR_ReciprocalResolution.xy).xyz;
 }
 
 // returns a value from 0 to 1 based on the positions of a value between a min/max 
 float invLerp(float from, float to, float value){
   return (value - from) / (to - from);
 }
- 
-float readDepth(in float2 coord : TEXCOORD0)
-{
-	float Depth = tex2D(TESR_DepthBuffer, coord).x;;
-    float ViewZ = (-nearZ *Q) / (Depth - Q);
-	return ViewZ;
-}
 
-
-float3 reconstructPosition(float2 uv)
-{
-	float4 screenpos = float4(uv * 2.0 - 1.0f, tex2D(TESR_DepthBuffer, uv).x, 1.0f);
-	screenpos.y = -screenpos.y;
-	float4 viewpos = mul(screenpos, TESR_InvProjectionTransform);
-	viewpos.xyz /= viewpos.w;
-	return viewpos.xyz;
-}
-
-float3 projectPosition(float3 position){
-	float4 projection = mul(float4 (position, 1.0), TESR_ProjectionTransform);
-	projection.xyz /= projection.w;
-	projection.x = projection.x * 0.5 + 0.5;
-	projection.y = 0.5 - 0.5 * projection.y;
-
-	return projection.xyz;
-}
-
-float3 GetNormal( float2 uv)
-{
-	// improved normal reconstruction algorithm from 
-	// https://gist.github.com/bgolus/a07ed65602c009d5e2f753826e8078a0
-
-	// store coordinates at 1 and 2 pixels from center in all directions
-	float4 rightUv = uv.xyxy + float4(1.0, 0.0, 2.0, 0.0) * texelSize.xyxy; 
-	float4 leftUv = uv.xyxy + float4(-1.0, 0.0, -2.0, 0.0) * texelSize.xyxy; 
-	float4 bottomUv = uv.xyxy + float4(0.0, 1.0, 0.0, 2.0) * texelSize.xyxy; 
-	float4 topUv =uv.xyxy + float4(0.0, -1.0, 0.0, -2.0) * texelSize.xyxy; 
-
-	float depth = readDepth(uv);
-
-	// get depth values at 1 & 2 pixels offsets from current along the horizontal axis
-	half4 H = half4(
-		readDepth(rightUv.xy),
-		readDepth(leftUv.xy),
-		readDepth(rightUv.zw),
-		readDepth(leftUv.zw)
-	);
-
-	// get depth values at 1 & 2 pixels offsets from current along the vertical axis
-	half4 V = half4(
-		readDepth(topUv.xy),
-		readDepth(bottomUv.xy),
-		readDepth(topUv.zw),
-		readDepth(bottomUv.zw)
-	);
-
-	half2 he = abs((2 * H.xy - H.zw) - depth);
-	half2 ve = abs((2 * V.xy - V.zw) - depth);
-
-	// pick horizontal and vertical diff with the smallest depth difference from slopes
-	float3 centerPoint = reconstructPosition(uv);
-	float3 rightPoint = reconstructPosition(rightUv.xy);
-	float3 leftPoint = reconstructPosition(leftUv.xy);
-	float3 topPoint = reconstructPosition(topUv.xy);
-	float3 bottomPoint = reconstructPosition(bottomUv.xy);
-	float3 left = centerPoint - leftPoint;
-	float3 right = rightPoint - centerPoint;
-	float3 down = centerPoint - bottomPoint;
-	float3 up = topPoint - centerPoint;
-
-	half3 hDeriv = he.x < he.y ? left : right;
-	half3 vDeriv = ve.x < ve.y ? down : up;
-
-	// get view space normal from the cross product of the best derivatives
-	// half3 viewNormal = normalize(cross(hDeriv, vDeriv));
-	half3 viewNormal = normalize(cross(vDeriv, hDeriv));
-
-	return viewNormal;
-}
 
 
 float unpackDepth(float2 depth)
@@ -208,7 +86,6 @@ float4 SSAO(VSOUT IN) : COLOR0
 	float2 coord = IN.UVCoord;
 
 	// generate the sampling kernel with random points in a hemisphere
-	// int kernelSize = clamp(int(AOsamples), 0, 8);
 	int kernelSize = 20;
 	float3 kernel[20]; // max supported kernel size is 32 samples
 	float uRadius = abs(AOrange);
@@ -237,7 +114,7 @@ float4 SSAO(VSOUT IN) : COLOR0
 	float occlusion = 0.0;
 	for (i = 0; i < kernelSize; ++i) {
 		// get sample positions around origin:
-		if (dot(normal, kernel[i]) < 0.0) kernel[i] *= -1.0; // if our sample vector goes inside the geometry, we flip it
+		kernel[i] *= dot(normal, kernel[i]) < 0.0 ? -1.0 : 1.0; // if our sample vector goes inside the geometry, we flip it
 		float3 samplePoint = origin + kernel[i] * uRadius;
 		
 		// compare depth of the projected sample with the value from depthbuffer
@@ -250,15 +127,9 @@ float4 SSAO(VSOUT IN) : COLOR0
 		float rangeCheck = distance < uRadius ? 1.0 : 0.0;
 		float influence = (sampleDepth < actualDepth ? 1.0 : 0.0 ) * rangeCheck;
 
-		if (influence){
-			if ( i < kernelSize / 4) {
-				// stronger strength curve in close vectors
-				influence = 1.0 - distance * distance/(uRadius * uRadius);
-			} else {
-				influence = 1.0 - distance /uRadius;
-			}
-			occlusion += influence;
-		}
+		// stronger strength curve in close vectors (replacing an if statement with a lerp)
+		influence *= lerp(1.0 - distance * distance/(uRadius * uRadius), 1.0 - distance /uRadius, i < kernelSize / 4);
+		occlusion += influence;
 	}
 	
 	occlusion = 1.0 - occlusion/kernelSize * AOstrength;
@@ -266,42 +137,10 @@ float4 SSAO(VSOUT IN) : COLOR0
 	float fogColor = Desaturate(TESR_FogColor).x;
 	float darkness = clamp(lerp(occlusion, fogColor, fogCoeff(origin.z)), occlusion, 1.0);
 
-	if (origin.z > startFade){
-		darkness = lerp(darkness, 1.0, saturate(invLerp(0.0, endFade, origin.z)));
-	}
+	darkness = lerp(darkness, 1.0, saturate(invLerp(0.0, endFade, origin.z)));
+	// darkness = lerp(darkness, 1.0, saturate(invLerp(startFade, endFade, origin.z)));
 
 	return float4(darkness, packDepth(origin.z), 1.0);
-}
-
- 
-// perform depth aware 12 taps blur along the direction of the offsetmask
-float4 BlurPS(VSOUT IN, uniform float2 OffsetMask) : COLOR0
-{
-	float WeightSum = 0.114725602f;
-	float4 ao = tex2D(TESR_RenderedBuffer, IN.UVCoord);
-	ao.r = ao.r * WeightSum;
-
-	// float Depth1 = unpackDepth(ao.gb);
-	float Depth1 = readDepth(IN.UVCoord);
-	clip(endFade - Depth1);
-
-	int i = 0;
-    for (i = 0; i < cKernelSize; i++)
-    {
-		float2 uvOff = (BlurOffsets[i] * OffsetMask) * AOblurRadius;
-		float4 Color = tex2D(TESR_RenderedBuffer, IN.UVCoord + uvOff);
-		float Depth2 = readDepth(IN.UVCoord + uvOff);
-		// float Depth2 = unpackDepth(Color.gb);
-		float diff = abs(float(Depth1 - Depth2));
- 
-		if(diff <= AOblurDrop)
-		{
-			ao.r += BlurWeights[i] * Color.r;
-			WeightSum += BlurWeights[i];
-		}
-    }
-	ao.r /= WeightSum;
-    return ao;
 }
 
 
@@ -342,13 +181,13 @@ technique
 	pass
 	{ 
 		VertexShader = compile vs_3_0 FrameVS();
-		PixelShader = compile ps_3_0 BlurPS(float2(1.0f, 0.0f));
+		PixelShader = compile ps_3_0 BlurRChannel(float2(1.0f, 0.0f), blurRadius, blurDrop, endFade);
 	}
 	
 	pass
 	{ 
 		VertexShader = compile vs_3_0 FrameVS();
-		PixelShader = compile ps_3_0 BlurPS(float2(0.0f, 1.0f));
+		PixelShader = compile ps_3_0 BlurRChannel(float2(0.0f, 1.0f), blurRadius, blurDrop, endFade);
 	}
 	
 	pass

--- a/Extra/Shaders/NewVegasReloaded/Effects/Includes/Blending.hlsl
+++ b/Extra/Shaders/NewVegasReloaded/Effects/Includes/Blending.hlsl
@@ -1,0 +1,27 @@
+float4 alphaBlend(float4 base, float4 blend)
+{
+	return base*base.a +(1-base.a)*blend;
+}
+
+float4 Desaturate(float4 input)
+{
+	float greyscale = input.r * 0.3f + input.g * 0.59f +input.b * 0.11f;
+	return float4(greyscale, greyscale, greyscale, input.a);
+}
+
+// photoshop overlay blend mode code from https://www.ryanjuckett.com/photoshop-blend-modes-in-hlsl/
+float BlendMode_Overlay(float base, float blend)
+{
+	return (base <= 0.5f) ? 2.0f*base*blend : 1.0f - 2.0f*(1.0f-base)*(1.0f-blend);
+}
+
+float4 BlendMode_Overlay(float4 base, float4 blend)
+{
+	float4 result = float4(0,0,0,0);
+	result.r = BlendMode_Overlay(base.r, blend.r);
+	result.g = BlendMode_Overlay(base.g, blend.g);
+	result.b = BlendMode_Overlay(base.b, blend.b);
+	result.a = blend.a;
+
+	return alphaBlend(result, base);
+}

--- a/Extra/Shaders/NewVegasReloaded/Effects/Includes/Blur.hlsl
+++ b/Extra/Shaders/NewVegasReloaded/Effects/Includes/Blur.hlsl
@@ -1,0 +1,60 @@
+static const int cKernelSize = 12;
+static const float BlurWeights[cKernelSize] = 
+{
+	0.057424882f,
+	0.058107773f,
+	0.061460144f,
+	0.071020611f,
+	0.088092873f,
+	0.106530916f,
+	0.106530916f,
+	0.088092873f,
+	0.071020611f,
+	0.061460144f,
+	0.058107773f,
+	0.057424882f
+};
+ 
+static const float2 BlurOffsets[cKernelSize] = 
+{
+	float2(-6.0f * TESR_ReciprocalResolution.x, -6.0f * TESR_ReciprocalResolution.y),
+	float2(-5.0f * TESR_ReciprocalResolution.x, -5.0f * TESR_ReciprocalResolution.y),
+	float2(-4.0f * TESR_ReciprocalResolution.x, -4.0f * TESR_ReciprocalResolution.y),
+	float2(-3.0f * TESR_ReciprocalResolution.x, -3.0f * TESR_ReciprocalResolution.y),
+	float2(-2.0f * TESR_ReciprocalResolution.x, -2.0f * TESR_ReciprocalResolution.y),
+	float2(-1.0f * TESR_ReciprocalResolution.x, -1.0f * TESR_ReciprocalResolution.y),
+	float2( 1.0f * TESR_ReciprocalResolution.x,  1.0f * TESR_ReciprocalResolution.y),
+	float2( 2.0f * TESR_ReciprocalResolution.x,  2.0f * TESR_ReciprocalResolution.y),
+	float2( 3.0f * TESR_ReciprocalResolution.x,  3.0f * TESR_ReciprocalResolution.y),
+	float2( 4.0f * TESR_ReciprocalResolution.x,  4.0f * TESR_ReciprocalResolution.y),
+	float2( 5.0f * TESR_ReciprocalResolution.x,  5.0f * TESR_ReciprocalResolution.y),
+	float2( 6.0f * TESR_ReciprocalResolution.x,  6.0f * TESR_ReciprocalResolution.y)
+};
+
+// perform depth aware 12 taps blur along the direction of the offsetmask
+float4 BlurRChannel(VSOUT IN, uniform float2 OffsetMask, uniform float blurRadius,uniform float depthDrop,uniform float endFade) : COLOR0
+{
+	float WeightSum = 0.114725602f;
+	float4 color1 = tex2D(TESR_RenderedBuffer, IN.UVCoord);
+	color1.r = color1.r * WeightSum;
+
+	// float Depth1 = unpackDepth(ao.gb);
+	float depth1 = readDepth(IN.UVCoord);
+	clip(endFade - depth1);
+
+	int i = 0;
+    for (i = 0; i < cKernelSize; i++)
+    {
+		float2 uvOff = (BlurOffsets[i] * OffsetMask) * blurRadius;
+		float4 color2 = tex2D(TESR_RenderedBuffer, IN.UVCoord + uvOff).r;
+		float depth2 = readDepth(IN.UVCoord + uvOff);
+		// float Depth2 = unpackDepth(Color.gb);
+		float diff = abs(float(depth1 - depth2));
+
+		int useForBlur = (diff <= depthDrop);
+		color1.r += BlurWeights[i] * color2.r * useForBlur;
+		WeightSum += BlurWeights[i] * useForBlur;
+    }
+	color1.r /= WeightSum;
+    return color1;
+}

--- a/Extra/Shaders/NewVegasReloaded/Effects/Includes/Depth.hlsl
+++ b/Extra/Shaders/NewVegasReloaded/Effects/Includes/Depth.hlsl
@@ -1,0 +1,89 @@
+// A collection of functions that allow to query depth of a given pixel and also to reconstruct/project a point from screen to view space
+// requires the shader to get access to the TESR_DepthBuffer sampler before the include.
+
+float4x4 TESR_ProjectionTransform;
+float4x4 TESR_InvProjectionTransform;
+float4 TESR_DepthConstants;
+float4 TESR_CameraData;
+static const float nearZ = TESR_CameraData.x;
+static const float farZ = TESR_CameraData.y;
+static const float Q = farZ/(farZ - nearZ);
+
+float readDepth(in float2 coord : TEXCOORD0)
+{
+	float Depth = tex2D(TESR_DepthBuffer, coord).x;;
+    float ViewZ = (-nearZ *Q) / (Depth - Q);
+	return ViewZ;
+}
+
+float3 reconstructPosition(float2 uv)
+{
+    float4 screenpos = float4(uv * 2.0 - 1.0f, tex2D(TESR_DepthBuffer, uv).x, 1.0f);
+    screenpos.y = -screenpos.y;
+    float4 viewpos = mul(screenpos, TESR_InvProjectionTransform);
+    viewpos.xyz /= viewpos.w;
+    return viewpos.xyz;
+}
+
+float3 projectPosition(float3 position){
+	float4 projection = mul(float4 (position, 1.0), TESR_ProjectionTransform);
+	projection.xyz /= projection.w;
+
+	projection.x = projection.x * 0.5 + 0.5;
+	projection.y = 0.5 - 0.5 * projection.y;
+
+	return projection.xyz;
+}
+
+float3 GetNormal( float2 uv)
+{
+	// improved normal reconstruction algorithm from 
+	// https://gist.github.com/bgolus/a07ed65602c009d5e2f753826e8078a0
+
+	// store coordinates at 1 and 2 pixels from center in all directions
+	float4 rightUv = uv.xyxy + float4(1.0, 0.0, 2.0, 0.0) * TESR_ReciprocalResolution.xyxy; 
+	float4 leftUv = uv.xyxy + float4(-1.0, 0.0, -2.0, 0.0) * TESR_ReciprocalResolution.xyxy; 
+	float4 bottomUv = uv.xyxy + float4(0.0, 1.0, 0.0, 2.0) * TESR_ReciprocalResolution.xyxy; 
+	float4 topUv =uv.xyxy + float4(0.0, -1.0, 0.0, -2.0) * TESR_ReciprocalResolution.xyxy; 
+
+	float depth = readDepth(uv);
+
+	// get depth values at 1 & 2 pixels offsets from current along the horizontal axis
+	float4 H = float4(
+		readDepth(rightUv.xy),
+		readDepth(leftUv.xy),
+		readDepth(rightUv.zw),
+		readDepth(leftUv.zw)
+	);
+
+	// get depth values at 1 & 2 pixels offsets from current along the vertical axis
+	float4 V = float4(
+		readDepth(topUv.xy),
+		readDepth(bottomUv.xy),
+		readDepth(topUv.zw),
+		readDepth(bottomUv.zw)
+	);
+
+	float2 he = abs((2 * H.xy - H.zw) - depth);
+	float2 ve = abs((2 * V.xy - V.zw) - depth);
+
+	// pick horizontal and vertical diff with the smallest depth difference from slopes
+	float3 centerPoint = reconstructPosition(uv);
+	float3 rightPoint = reconstructPosition(rightUv.xy);
+	float3 leftPoint = reconstructPosition(leftUv.xy);
+	float3 topPoint = reconstructPosition(topUv.xy);
+	float3 bottomPoint = reconstructPosition(bottomUv.xy);
+	float3 left = centerPoint - leftPoint;
+	float3 right = rightPoint - centerPoint;
+	float3 down = centerPoint - bottomPoint;
+	float3 up = topPoint - centerPoint;
+
+	float3 hDeriv = he.x < he.y ? left : right;
+	float3 vDeriv = ve.x < ve.y ? down : up;
+
+	// get view space normal from the cross product of the best derivatives
+	// half3 viewNormal = normalize(cross(hDeriv, vDeriv));
+	float3 viewNormal = normalize(cross(vDeriv, hDeriv));
+
+	return viewNormal;
+}

--- a/Extra/Shaders/NewVegasReloaded/Effects/Includes/Depth.hlsl
+++ b/Extra/Shaders/NewVegasReloaded/Effects/Includes/Depth.hlsl
@@ -3,8 +3,13 @@
 
 float4x4 TESR_ProjectionTransform;
 float4x4 TESR_InvProjectionTransform;
+float4x4 TESR_InvViewTransform;
+float4x4 TESR_ViewTransform;
+float4x4 TESR_InvWorldViewProjectionTransform;
 float4 TESR_DepthConstants;
 float4 TESR_CameraData;
+float4 TESR_CameraPosition;
+
 static const float nearZ = TESR_CameraData.x;
 static const float farZ = TESR_CameraData.y;
 static const float Q = farZ/(farZ - nearZ);
@@ -33,6 +38,29 @@ float3 projectPosition(float3 position){
 	projection.y = 0.5 - 0.5 * projection.y;
 
 	return projection.xyz;
+}
+
+
+float3 toWorld(float2 tex)
+{
+	float3 v = float3(TESR_ViewTransform[0][2], TESR_ViewTransform[1][2], TESR_ViewTransform[2][2]);
+	v += (1 / TESR_ProjectionTransform[0][0] * (2 * tex.x - 1)).xxx * float3(TESR_ViewTransform[0][0], TESR_ViewTransform[1][0], TESR_ViewTransform[2][0]);
+	v += (-1 / TESR_ProjectionTransform[1][1] * (2 * tex.y - 1)).xxx * float3(TESR_ViewTransform[0][1], TESR_ViewTransform[1][1], TESR_ViewTransform[2][1]);
+	return v;
+}
+
+float4 reconstructWorldPosition(float2 uv){
+    // float4 screenpos = float4(uv * 2.0 - 1.0f, tex2D(TESR_DepthBuffer, uv).x, 1.0f);
+    // screenpos.y = -screenpos.y;
+    // float4 viewpos = mul(screenpos, TESR_InvWorldViewProjectionTransform);
+    // viewpos.xyz /= viewpos.w;
+    // return viewpos;
+
+
+	float depth = readDepth(uv);
+	float3 camera_vector = toWorld(uv) * depth;
+	float4 world_pos = float4(TESR_CameraPosition.xyz + camera_vector, 1.0f);
+	return world_pos;
 }
 
 float3 GetNormal( float2 uv)
@@ -86,4 +114,11 @@ float3 GetNormal( float2 uv)
 	float3 viewNormal = normalize(cross(vDeriv, hDeriv));
 
 	return viewNormal;
+}
+
+
+float3 GetWorldNormal( float2 uv)
+{
+	float3 normal = GetNormal(uv);
+	return mul(TESR_ViewTransform, normal);
 }

--- a/Extra/Shaders/NewVegasReloaded/Effects/ShadowsExteriors.fx.hlsl
+++ b/Extra/Shaders/NewVegasReloaded/Effects/ShadowsExteriors.fx.hlsl
@@ -257,10 +257,10 @@ float4 ScreenSpaceShadow(VSOUT IN) : COLOR0
 
 float attenuation(float4 world_pos, float4 lightPosition){
 	float coeff = 6000; // conversion value between diffuse/dimmer strength and attenuation effect
-	float strength = 1 / distance(lightPosition.xyz, world_pos.xyz);
+	float strength = distance(lightPosition.xyz, world_pos.xyz);
 
 	// inverse square law with conversion coeff and light strength influence
-	return strength * strength * coeff * lightPosition.w;
+	return 1/(strength * strength) * coeff * lightPosition.w;
 }
 
 float4 Shadow(VSOUT IN) : COLOR0
@@ -273,7 +273,7 @@ float4 Shadow(VSOUT IN) : COLOR0
 
 	float4 pos = mul(world_pos, TESR_WorldViewProjectionTransform);
 
-	Shadow = saturate(GetLightAmount(pos, depth));
+	Shadow = saturate(GetLightAmount(pos, depth)) + TESR_ShadowFade.y; //turn off shadow maps if settings disabled
 	Shadow = min(tex2D(TESR_RenderedBuffer, IN.UVCoord).r, Shadow);
 
 	// fade shadows to light when sun is low

--- a/Extra/Shaders/NewVegasReloaded/Effects/ShadowsExteriors.fx.hlsl
+++ b/Extra/Shaders/NewVegasReloaded/Effects/ShadowsExteriors.fx.hlsl
@@ -123,7 +123,7 @@ float invLerp(float from, float to, float value){
 }
 
 float fogCoeff(float depth){
-	return clamp(invLerp(TESR_FogDistance.x, TESR_FogDistance.y, depth), 0.0, 1.0) / TESR_FogDistance.z;
+	return saturate(invLerp(TESR_FogDistance.x, TESR_FogDistance.y, depth));
 }
 
 float GetLightAmountValue(sampler2D shadowBuffer, float4x4 lightTransform, float4 coord){
@@ -256,10 +256,11 @@ float4 ScreenSpaceShadow(VSOUT IN) : COLOR0
 }
 
 float attenuation(float4 world_pos, float4 lightPosition){
-	float coeff = 50000;
+	float coeff = 6000; // conversion value between diffuse/dimmer strength and attenuation effect
 	float strength = 1 / distance(lightPosition.xyz, world_pos.xyz);
 
-	return strength * strength * coeff;
+	// inverse square law with conversion coeff and light strength influence
+	return strength * strength * coeff * lightPosition.w;
 }
 
 float4 Shadow(VSOUT IN) : COLOR0
@@ -327,6 +328,11 @@ technique {
 		PixelShader = compile ps_3_0 ScreenSpaceShadow();
 	}
 
+	pass {
+		VertexShader = compile vs_3_0 FrameVS();
+		PixelShader = compile ps_3_0 Shadow();
+	}
+
 	pass
 	{ 
 		VertexShader = compile vs_3_0 FrameVS();
@@ -338,12 +344,6 @@ technique {
 		VertexShader = compile vs_3_0 FrameVS();
 		PixelShader = compile ps_3_0 BlurRChannel(float2(0.0f, 1.0f), TESR_ShadowScreenSpaceData.y, 5, SSS_MAXDEPTH);
 	}
-
-	pass {
-		VertexShader = compile vs_3_0 FrameVS();
-		PixelShader = compile ps_3_0 Shadow();
-	}
-
 
 	pass {
 		VertexShader = compile vs_3_0 FrameVS();

--- a/Extra/Shaders/NewVegasReloaded/Effects/Specular.fx.hlsl
+++ b/Extra/Shaders/NewVegasReloaded/Effects/Specular.fx.hlsl
@@ -1,58 +1,17 @@
 // Specular multiplier fullscreen shader for Oblivion/Skyrim Reloaded
 
-float4x4 TESR_ProjectionTransform;
-float4x4 TESR_InvProjectionTransform;
 float4 TESR_ReciprocalResolution;
 float4 TESR_SpecularData;					// x: strength, y:blurMultiplier, z:glossiness, w:drawDistance
-float4 TESR_CameraData;  					// x: nearZ, y: farZ, z: aspect ratio, w: fov
-float4 TESR_ScreenSpaceLightDir;
+float4 TESR_ViewSpaceLightDir;
 
 sampler2D TESR_RenderedBuffer : register(s0) = sampler_state { ADDRESSU = CLAMP; ADDRESSV = CLAMP; MAGFILTER = LINEAR; MINFILTER = LINEAR; MIPFILTER = LINEAR; };
 sampler2D TESR_DepthBuffer : register(s1) = sampler_state { ADDRESSU = CLAMP; ADDRESSV = CLAMP; MAGFILTER = LINEAR; MINFILTER = LINEAR; MIPFILTER = LINEAR; };
 sampler2D TESR_SourceBuffer : register(s2) = sampler_state { ADDRESSU = CLAMP; ADDRESSV = CLAMP; MAGFILTER = LINEAR; MINFILTER = LINEAR; MIPFILTER = LINEAR; };
 
-static const float nearZ = TESR_CameraData.x;
-static const float farZ = TESR_CameraData.y;
-static const float Q = farZ/(farZ - nearZ);
-
 static const float Strength = TESR_SpecularData.x;
 static const float BlurRadius = TESR_SpecularData.y;
 static const float Glossiness = TESR_SpecularData.z;
 static const float DrawDistance = TESR_SpecularData.w;
-static const float2 texelSize = float2(TESR_ReciprocalResolution.x, TESR_ReciprocalResolution.y);
-static const int cKernelSize = 12;
-
-static const float BlurWeights[cKernelSize] = 
-{
-	0.057424882f,
-	0.058107773f,
-	0.061460144f,
-	0.071020611f,
-	0.088092873f,
-	0.106530916f,
-	0.106530916f,
-	0.088092873f,
-	0.071020611f,
-	0.061460144f,
-	0.058107773f,
-	0.057424882f
-};
- 
-static const float2 BlurOffsets[cKernelSize] = 
-{
-	float2(-6.0f * TESR_ReciprocalResolution.x, -6.0f * TESR_ReciprocalResolution.y),
-	float2(-5.0f * TESR_ReciprocalResolution.x, -5.0f * TESR_ReciprocalResolution.y),
-	float2(-4.0f * TESR_ReciprocalResolution.x, -4.0f * TESR_ReciprocalResolution.y),
-	float2(-3.0f * TESR_ReciprocalResolution.x, -3.0f * TESR_ReciprocalResolution.y),
-	float2(-2.0f * TESR_ReciprocalResolution.x, -2.0f * TESR_ReciprocalResolution.y),
-	float2(-1.0f * TESR_ReciprocalResolution.x, -1.0f * TESR_ReciprocalResolution.y),
-	float2( 1.0f * TESR_ReciprocalResolution.x,  1.0f * TESR_ReciprocalResolution.y),
-	float2( 2.0f * TESR_ReciprocalResolution.x,  2.0f * TESR_ReciprocalResolution.y),
-	float2( 3.0f * TESR_ReciprocalResolution.x,  3.0f * TESR_ReciprocalResolution.y),
-	float2( 4.0f * TESR_ReciprocalResolution.x,  4.0f * TESR_ReciprocalResolution.y),
-	float2( 5.0f * TESR_ReciprocalResolution.x,  5.0f * TESR_ReciprocalResolution.y),
-	float2( 6.0f * TESR_ReciprocalResolution.x,  6.0f * TESR_ReciprocalResolution.y)
-};
  
 struct VSOUT
 {
@@ -73,76 +32,9 @@ VSOUT FrameVS(VSIN IN)
 	OUT.UVCoord = IN.UVCoord;
 	return OUT;
 }
- 
-float readDepth(in float2 coord : TEXCOORD0)
-{
-	float Depth = tex2D(TESR_DepthBuffer, coord).x;;
-    float ViewZ = (-nearZ *Q) / (Depth - Q);
-	return ViewZ;
-}
 
-float3 reconstructPosition(float2 uv)
-{
-	float4 screenpos = float4(uv * 2.0 - 1.0f, tex2D(TESR_DepthBuffer, uv).x, 1.0f);
-	screenpos.y = -screenpos.y;
-	float4 viewpos = mul(screenpos, TESR_InvProjectionTransform);
-	viewpos.xyz /= viewpos.w;
-	return viewpos.xyz;
-}
-
-float3 GetNormal( float2 uv)
-{
-	// improved normal reconstruction algorithm from 
-	// https://gist.github.com/bgolus/a07ed65602c009d5e2f753826e8078a0
-
-	// store coordinates at 1 and 2 pixels from center in all directions
-	float4 rightUv = uv.xyxy + float4(1.0, 0.0, 2.0, 0.0) * texelSize.xyxy; 
-	float4 leftUv = uv.xyxy + float4(-1.0, 0.0, -2.0, 0.0) * texelSize.xyxy; 
-	float4 bottomUv = uv.xyxy + float4(0.0, 1.0, 0.0, 2.0) * texelSize.xyxy; 
-	float4 topUv =uv.xyxy + float4(0.0, -1.0, 0.0, -2.0) * texelSize.xyxy; 
-
-	float depth = readDepth(uv);
-
-	// get depth values at 1 & 2 pixels offsets from current along the horizontal axis
-	half4 H = half4(
-		readDepth(rightUv.xy),
-		readDepth(leftUv.xy),
-		readDepth(rightUv.zw),
-		readDepth(leftUv.zw)
-	);
-
-	// get depth values at 1 & 2 pixels offsets from current along the vertical axis
-	half4 V = half4(
-		readDepth(topUv.xy),
-		readDepth(bottomUv.xy),
-		readDepth(topUv.zw),
-		readDepth(bottomUv.zw)
-	);
-
-	half2 he = abs((2 * H.xy - H.zw) - depth);
-	half2 ve = abs((2 * V.xy - V.zw) - depth);
-
-	// pick horizontal and vertical diff with the smallest depth difference from slopes
-	float3 centerPoint = reconstructPosition(uv);
-	float3 rightPoint = reconstructPosition(rightUv.xy);
-	float3 leftPoint = reconstructPosition(leftUv.xy);
-	float3 topPoint = reconstructPosition(topUv.xy);
-	float3 bottomPoint = reconstructPosition(bottomUv.xy);
-	float3 left = centerPoint - leftPoint;
-	float3 right = rightPoint - centerPoint;
-	float3 down = centerPoint - bottomPoint;
-	float3 up = topPoint - centerPoint;
-
-	half3 hDeriv = he.x < he.y ? left : right;
-	half3 vDeriv = ve.x < ve.y ? down : up;
-
-	// get view space normal from the cross product of the best derivatives
-	// half3 viewNormal = normalize(cross(hDeriv, vDeriv));
-	half3 viewNormal = normalize(cross(vDeriv, hDeriv));
-
-	return viewNormal;
-}
-
+#include "Includes/Depth.hlsl"
+#include "Includes/Blur.hlsl"
 
 float4 Desaturate(float4 input)
 {
@@ -160,9 +52,9 @@ float4 specularHighlight( VSOUT IN) : COLOR0
 	//reorient our sample kernel along the origin's normal
 	float3 normal = GetNormal(IN.UVCoord);
 	float3 viewRay = normalize(origin);
-	float3 reflection = reflect(TESR_ScreenSpaceLightDir.xyz, normal);
+	float3 reflection = reflect(TESR_ViewSpaceLightDir.xyz, normal);
 
-	// float diffuse = dot(normal, TESR_ScreenSpaceLightDir.xyz);
+	// float diffuse = dot(normal, TESR_ViewSpaceLightDir.xyz);
 	float specular = pow(dot(viewRay, reflection), Glossiness) * Glossiness * Glossiness;
 	
 	specular = lerp(specular, 0.0, origin.z/DrawDistance);
@@ -170,36 +62,6 @@ float4 specularHighlight( VSOUT IN) : COLOR0
 	// return diffuse;
 	return specular.xxxx;
 	// return specular + diffuse;
-}
-
-
-// perform depth aware 12 taps blur along the direction of the offsetmask
-float4 BlurPS(VSOUT IN, uniform float2 OffsetMask) : COLOR0
-{
-	float WeightSum = 0.114725602f;
-	float4 color1 = tex2D(TESR_RenderedBuffer, IN.UVCoord);
-	color1.r = color1.r * WeightSum;
-
-	float depth1 = readDepth(IN.UVCoord);
-	clip(DrawDistance - depth1); //don't process pixels further away than effect fade distance
-
-	int i = 0;
-    for (i = 0; i < cKernelSize; i++)
-    {
-		float2 uvOff = (BlurOffsets[i] * OffsetMask) * BlurRadius;
-		float4 color2 = tex2D(TESR_RenderedBuffer, IN.UVCoord + uvOff);
-		float depth2 = readDepth(IN.UVCoord + uvOff);
-		float diff = abs(float(depth1 - depth2));
- 
-		// only factor it pixels that are close in terms of depth
-		if(diff <= 1)
-		{
-			color1.r += BlurWeights[i] * color2.r;
-			WeightSum += BlurWeights[i];
-		}
-    }
-	color1.r /= WeightSum;
-    return color1.rrrr;
 }
 
 
@@ -229,13 +91,13 @@ technique
 	pass
 	{ 
 		VertexShader = compile vs_3_0 FrameVS();
-		PixelShader = compile ps_3_0 BlurPS(float2(1.0f, 0.0f));
+		PixelShader = compile ps_3_0 BlurRChannel(float2(1.0f, 0.0f), BlurRadius, 1, DrawDistance);
 	}
 	
 	pass
 	{ 
 		VertexShader = compile vs_3_0 FrameVS();
-		PixelShader = compile ps_3_0 BlurPS(float2(0.0f, 1.0f));
+		PixelShader = compile ps_3_0 BlurRChannel(float2(0.0f, 1.0f), BlurRadius, 1, DrawDistance);
 	}
 
 	pass

--- a/TESReloaded/Core/SettingManager.cpp
+++ b/TESReloaded/Core/SettingManager.cpp
@@ -775,6 +775,10 @@ void SettingManager::LoadSettings() {
 	SettingsShadows.Exteriors.ShadowMode = GetSettingI("Shaders.ShadowsExteriors.Main", "ShadowMode");
 	SettingsShadows.Exteriors.BlurShadowMaps = GetSettingI("Shaders.ShadowsExteriors.Main", "BlurShadowMaps");
 
+	SettingsShadows.ScreenSpace.Enabled = GetSettingI("Shaders.ShadowsExteriors.ScreenSpace", "Enabled");
+	SettingsShadows.ScreenSpace.BlurRadius = GetSettingI("Shaders.ShadowsExteriors.ScreenSpace", "BlurRadius");
+	SettingsShadows.ScreenSpace.RenderDistance = GetSettingI("Shaders.ShadowsExteriors.ScreenSpace", "RenderDistance");
+
 	SettingsShadows.Exteriors.AlphaEnabled[ShadowManager::ShadowMapTypeEnum::MapNear] = GetSettingI("Shaders.ShadowsExteriors.Near", "AlphaEnabled");
 	SettingsShadows.Exteriors.Forms[ShadowManager::ShadowMapTypeEnum::MapNear].Activators = GetSettingI("Shaders.ShadowsExteriors.Near", "Activators");
 	SettingsShadows.Exteriors.Forms[ShadowManager::ShadowMapTypeEnum::MapNear].Actors = GetSettingI("Shaders.ShadowsExteriors.Near", "Actors");
@@ -816,7 +820,6 @@ void SettingManager::LoadSettings() {
 	SettingsShadows.Exteriors.Forms[ShadowManager::ShadowMapTypeEnum::MapFar].Terrain = GetSettingI("Shaders.ShadowsExteriors.Far", "Terrain");
 	SettingsShadows.Exteriors.Forms[ShadowManager::ShadowMapTypeEnum::MapFar].Trees = GetSettingI("Shaders.ShadowsExteriors.Far", "Trees");
 	SettingsShadows.Exteriors.Forms[ShadowManager::ShadowMapTypeEnum::MapFar].Lod = GetSettingI("Shaders.ShadowsExteriors.Far", "Lod");
-
 
 	SettingsShadows.Exteriors.AlphaEnabled[ShadowManager::ShadowMapTypeEnum::MapLod] = GetSettingI("Shaders.ShadowsExteriors.Lod", "AlphaEnabled");
 	SettingsShadows.Exteriors.Forms[ShadowManager::ShadowMapTypeEnum::MapLod].Activators = GetSettingI("Shaders.ShadowsExteriors.Lod", "Activators");

--- a/TESReloaded/Core/SettingManager.h
+++ b/TESReloaded/Core/SettingManager.h
@@ -296,6 +296,13 @@ struct SettingsShadowStruct {
 		ExcludedFormsList	ExcludedForms;
 	};
 
+	struct ScreenSpaceStruct {
+		bool				Enabled;
+		float				BlurRadius;
+		float				RenderDistance;
+	};
+
+	ScreenSpaceStruct	ScreenSpace;
 	ExteriorsStruct		Exteriors;
 	InteriorsStruct		Interiors;
 };

--- a/TESReloaded/Core/ShaderManager.cpp
+++ b/TESReloaded/Core/ShaderManager.cpp
@@ -90,6 +90,22 @@ void ShaderProgram::SetConstantTableValue(LPCSTR Name, UInt32 Index) {
 		FloatShaderValues[Index].Value = (D3DXVECTOR4*)&TheShaderManager->ShaderConst.ShadowMap.ShadowLightPosition[2];
 	else if (!strcmp(Name, "TESR_ShadowLightPosition3"))
 		FloatShaderValues[Index].Value = (D3DXVECTOR4*)&TheShaderManager->ShaderConst.ShadowMap.ShadowLightPosition[3];
+	else if (!strcmp(Name, "TESR_LightPosition0"))
+		FloatShaderValues[Index].Value = (D3DXVECTOR4*)&TheShaderManager->LightPosition[0];
+	else if (!strcmp(Name, "TESR_LightPosition1"))
+		FloatShaderValues[Index].Value = (D3DXVECTOR4*)&TheShaderManager->LightPosition[1];
+	else if (!strcmp(Name, "TESR_LightPosition2"))
+		FloatShaderValues[Index].Value = (D3DXVECTOR4*)&TheShaderManager->LightPosition[2];
+	else if (!strcmp(Name, "TESR_LightPosition3"))
+		FloatShaderValues[Index].Value = (D3DXVECTOR4*)&TheShaderManager->LightPosition[3];
+	else if (!strcmp(Name, "TESR_LightPosition4"))
+		FloatShaderValues[Index].Value = (D3DXVECTOR4*)&TheShaderManager->LightPosition[4];
+	else if (!strcmp(Name, "TESR_LightPosition5"))
+		FloatShaderValues[Index].Value = (D3DXVECTOR4*)&TheShaderManager->LightPosition[5];
+	else if (!strcmp(Name, "TESR_LightPosition6"))
+		FloatShaderValues[Index].Value = (D3DXVECTOR4*)&TheShaderManager->LightPosition[6];
+	else if (!strcmp(Name, "TESR_LightPosition7"))
+		FloatShaderValues[Index].Value = (D3DXVECTOR4*)&TheShaderManager->LightPosition[7];
 	else if (!strcmp(Name, "TESR_ShadowCubeMapBlend"))
 		FloatShaderValues[Index].Value = &TheShaderManager->ShaderConst.ShadowMap.ShadowCubeMapBlend;
 	else if (!strcmp(Name, "TESR_OcclusionWorldViewProjTransform"))

--- a/TESReloaded/Core/ShaderManager.cpp
+++ b/TESReloaded/Core/ShaderManager.cpp
@@ -821,6 +821,9 @@ void ShaderManager::UpdateConstants() {
 	float weatherPercent = WorldSky->weatherPercent;
 	float lastGameTime = ShaderConst.GameTime.y;
 
+	TheRenderManager->UpdateSceneCameraData();
+	TheRenderManager->SetupSceneCamera();
+
 	TimeGlobals* GameTimeGlobals = TimeGlobals::Get();
 	float GameHour = GameTimeGlobals->GameHour->data;
 	float DaysPassed = GameTimeGlobals->GameDaysPassed ? GameTimeGlobals->GameDaysPassed->data : 1.0f;
@@ -829,8 +832,6 @@ void ShaderManager::UpdateConstants() {
 	float SunriseEnd = WorldSky->GetSunriseEnd();
 	float SunsetStart = WorldSky->GetSunsetBegin();
 	float SunsetEnd = WorldSky->GetSunsetEnd();
-
-	TheRenderManager->UpdateSceneCameraData();
 
 	ShaderConst.GameTime.x = TimeGlobals::GetGameTime(); //time in milliseconds
 	ShaderConst.GameTime.y = GameHour; //time in hours
@@ -1912,7 +1913,8 @@ void ShaderManager::RenderEffects(IDirect3DSurface9* RenderTarget) {
 	TESWorldSpace* currentWorldSpace = Player->GetWorldSpace();
 	TESObjectCELL* currentCell = Player->parentCell;
 
-	TheRenderManager->SetupSceneCamera();
+	TheShaderManager->UpdateConstants();
+
 	Device->SetStreamSource(0, FrameVertex, 0, sizeof(FrameVS));
 	Device->SetFVF(FrameFVF);
 	Device->StretchRect(RenderTarget, NULL, RenderedSurface, NULL, D3DTEXF_NONE);

--- a/TESReloaded/Core/ShaderManager.cpp
+++ b/TESReloaded/Core/ShaderManager.cpp
@@ -34,9 +34,10 @@ void ShaderProgram::SetConstantTableValue(LPCSTR Name, UInt32 Index) {
 		FloatShaderValues[Index].Value = &TheShaderManager->ShaderConst.Skin.SkinColor;
 	else if (!strcmp(Name, "TESR_ShadowData"))
 		FloatShaderValues[Index].Value = &TheShaderManager->ShaderConst.Shadow.Data;
-	else if (!strcmp(Name, "TESR_ShadowRadius")) {
+	else if (!strcmp(Name, "TESR_ShadowScreenSpaceData"))
+		FloatShaderValues[Index].Value = &TheShaderManager->ShaderConst.Shadow.ScreenSpaceData;
+	else if (!strcmp(Name, "TESR_ShadowRadius"))
 		FloatShaderValues[Index].Value = &TheShaderManager->ShaderConst.ShadowMap.ShadowMapRadius;
-	}
 	else if (!strcmp(Name, "TESR_OrthoData"))
 		FloatShaderValues[Index].Value = &TheShaderManager->ShaderConst.Shadow.OrthoData;
 	else if (!strcmp(Name, "TESR_RainData"))
@@ -1537,6 +1538,10 @@ void ShaderManager::UpdateConstants() {
 			ShaderConst.Sharpening.Data.y = TheSettingManager->SettingsSharpening.Clamp;
 			ShaderConst.Sharpening.Data.z = TheSettingManager->SettingsSharpening.Offset;
 		}
+
+		ShaderConst.Shadow.ScreenSpaceData.x = TheSettingManager->SettingsShadows.ScreenSpace.Enabled;
+		ShaderConst.Shadow.ScreenSpaceData.y = TheSettingManager->SettingsShadows.ScreenSpace.BlurRadius;
+		ShaderConst.Shadow.ScreenSpaceData.z = TheSettingManager->SettingsShadows.ScreenSpace.RenderDistance;
 
 		if (TheSettingManager->SettingsMain.Effects.Specular) {
 			D3DXVECTOR4 exteriorData;

--- a/TESReloaded/Core/ShaderManager.cpp
+++ b/TESReloaded/Core/ShaderManager.cpp
@@ -1979,7 +1979,7 @@ void ShaderManager::RenderEffects(IDirect3DSurface9* RenderTarget) {
 		ColoringEffect->SetCT();
 		ColoringEffect->Render(Device, RenderTarget, RenderedSurface, false);
 	}
-	if (SpecularEffect->Enabled) {
+	if (SpecularEffect->Enabled && isExterior) {
 		Device->StretchRect(RenderTarget, NULL, SourceSurface, NULL, D3DTEXF_NONE);
 		SpecularEffect->SetCT();
 		SpecularEffect->Render(Device, RenderTarget, RenderedSurface, false);

--- a/TESReloaded/Core/ShaderManager.cpp
+++ b/TESReloaded/Core/ShaderManager.cpp
@@ -843,6 +843,8 @@ void ShaderManager::UpdateConstants() {
 	TheRenderManager->UpdateSceneCameraData();
 	TheRenderManager->SetupSceneCamera();
 
+	bool isExterior = Player->GetWorldSpace() || Player->parentCell->flags0 & TESObjectCELL::kFlags0_BehaveLikeExterior;
+
 	TimeGlobals* GameTimeGlobals = TimeGlobals::Get();
 	float GameHour = GameTimeGlobals->GameHour->data;
 	float DaysPassed = GameTimeGlobals->GameDaysPassed ? GameTimeGlobals->GameDaysPassed->data : 1.0f;
@@ -906,7 +908,7 @@ void ShaderManager::UpdateConstants() {
 			ShaderConst.ShadowFade.x = lerp(MoonVisibility, 1, ShaderConst.ShadowFade.x);
 		}
 
-		if (currentWorldSpace) {
+		if (isExterior) {
 			if (currentWeather) {
 				// calculating fog color/fog amount based on sun amount
 				ShaderConst.SunDir.w = 1.0f;
@@ -1938,6 +1940,7 @@ void ShaderManager::RenderEffects(IDirect3DSurface9* RenderTarget) {
 	IDirect3DSurface9* RenderedSurface = TheTextureManager->RenderedSurface;
 	TESWorldSpace* currentWorldSpace = Player->GetWorldSpace();
 	TESObjectCELL* currentCell = Player->parentCell;
+	bool isExterior = Player->GetWorldSpace() || Player->parentCell->flags0 & TESObjectCELL::kFlags0_BehaveLikeExterior;
 
 	TheShaderManager->UpdateConstants();
 
@@ -1960,12 +1963,11 @@ void ShaderManager::RenderEffects(IDirect3DSurface9* RenderTarget) {
 		AmbientOcclusionEffect->SetCT();
 		AmbientOcclusionEffect->Render(Device, RenderTarget, RenderedSurface, false);
 	}
-	if (ShadowsExteriorsEffect->Enabled && currentWorldSpace) {
+	if (ShadowsExteriorsEffect->Enabled && isExterior) {
 		Device->StretchRect(RenderTarget, NULL, SourceSurface, NULL, D3DTEXF_NONE);
 		ShadowsExteriorsEffect->SetCT();
 		ShadowsExteriorsEffect->Render(Device, RenderTarget, RenderedSurface, false);
-	}
-	if (ShadowsInteriorsEffect->Enabled && !currentWorldSpace) {
+	}else if (ShadowsInteriorsEffect->Enabled) {
 		Device->StretchRect(RenderTarget, NULL, SourceSurface, NULL, D3DTEXF_NONE);
 		ShadowsInteriorsEffect->SetCT();
 		ShadowsInteriorsEffect->Render(Device, RenderTarget, RenderedSurface, false);
@@ -1974,7 +1976,7 @@ void ShaderManager::RenderEffects(IDirect3DSurface9* RenderTarget) {
 		ColoringEffect->SetCT();
 		ColoringEffect->Render(Device, RenderTarget, RenderedSurface, false);
 	}
-	if (SpecularEffect->Enabled && currentWorldSpace) {
+	if (SpecularEffect->Enabled) {
 		Device->StretchRect(RenderTarget, NULL, SourceSurface, NULL, D3DTEXF_NONE);
 		SpecularEffect->SetCT();
 		SpecularEffect->Render(Device, RenderTarget, RenderedSurface, false);

--- a/TESReloaded/Core/ShaderManager.cpp
+++ b/TESReloaded/Core/ShaderManager.cpp
@@ -909,6 +909,9 @@ void ShaderManager::UpdateConstants() {
 		}
 
 		if (isExterior) {
+			// pass the enabled/disabled property of the shadow maps to the shadowfade constant
+			ShaderConst.ShadowFade.y = !TheSettingManager->SettingsShadows.Exteriors.Enabled;
+
 			if (currentWeather) {
 				// calculating fog color/fog amount based on sun amount
 				ShaderConst.SunDir.w = 1.0f;

--- a/TESReloaded/Core/ShaderManager.cpp
+++ b/TESReloaded/Core/ShaderManager.cpp
@@ -57,6 +57,8 @@ void ShaderProgram::SetConstantTableValue(LPCSTR Name, UInt32 Index) {
 		FloatShaderValues[Index].Value = (D3DXVECTOR4*)&TheRenderManager->InvViewProjMatrix;
 	else if (!strcmp(Name, "TESR_ViewProjectionTransform"))
 		FloatShaderValues[Index].Value = (D3DXVECTOR4*)&TheRenderManager->ViewProjMatrix;
+	else if (!strcmp(Name, "TESR_ViewSpaceLightDir"))
+		FloatShaderValues[Index].Value = (D3DXVECTOR4*)&TheShaderManager->ShaderConst.ViewSpaceLightDir;
 	else if (!strcmp(Name, "TESR_ScreenSpaceLightDir"))
 		FloatShaderValues[Index].Value = (D3DXVECTOR4*)&TheShaderManager->ShaderConst.ScreenSpaceLightDir;
 	else if (!strcmp(Name, "TESR_ShadowWorldTransform"))
@@ -849,11 +851,14 @@ void ShaderManager::UpdateConstants() {
 			ShaderConst.SunDir.x = Tes->directionalLight->direction.x * -1;
 			ShaderConst.SunDir.y = Tes->directionalLight->direction.y * -1;
 			ShaderConst.SunDir.z = Tes->directionalLight->direction.z * -1;
-
-			// expose the light vector in view space for screen space lighting
-			D3DXVec4Transform(&ShaderConst.ScreenSpaceLightDir, &ShaderConst.SunDir, &TheRenderManager->ViewMatrix);
-			D3DXVec4Normalize(&ShaderConst.ScreenSpaceLightDir, &ShaderConst.ScreenSpaceLightDir);
 		}
+
+		// expose the light vector in view space for screen space lighting
+		D3DXVec4Transform(&ShaderConst.ScreenSpaceLightDir, &ShaderConst.SunDir, &TheRenderManager->ViewProjMatrix);
+		D3DXVec4Normalize(&ShaderConst.ScreenSpaceLightDir, &ShaderConst.ScreenSpaceLightDir);
+
+		D3DXVec4Transform(&ShaderConst.ViewSpaceLightDir, &ShaderConst.SunDir, &TheRenderManager->ViewMatrix);
+		D3DXVec4Normalize(&ShaderConst.ViewSpaceLightDir, &ShaderConst.ViewSpaceLightDir);
 
 		// fade shadows at sunrise/sunset
 		float shadowFadeTime = 1.0f;

--- a/TESReloaded/Core/ShaderManager.h
+++ b/TESReloaded/Core/ShaderManager.h
@@ -368,6 +368,6 @@ public:
 	NiD3DPixelShader*		WaterPixelShaders[51];
     TESObjectCELL*          PreviousCell;
     bool                    IsMenuSwitch;
-	
+	D3DXVECTOR4				LightPosition[8];
 };
 

--- a/TESReloaded/Core/ShaderManager.h
+++ b/TESReloaded/Core/ShaderManager.h
@@ -133,6 +133,7 @@ struct ShaderConstants {
 	D3DXVECTOR4				SunTiming;
 	D3DXVECTOR4				SunAmount;
 	D3DXVECTOR4				ShadowFade;
+	D3DXVECTOR4				ViewSpaceLightDir;
 	D3DXVECTOR4				ScreenSpaceLightDir;
 	D3DXVECTOR4				GameTime;
 	TESWeather*				pWeather;

--- a/TESReloaded/Core/ShaderManager.h
+++ b/TESReloaded/Core/ShaderManager.h
@@ -50,6 +50,7 @@ struct ShaderConstants {
 	};
 	struct ShadowStruct {
 		D3DXVECTOR4		Data;
+		D3DXVECTOR4		ScreenSpaceData;
 		D3DXVECTOR4		OrthoData;
 	};
 	struct PrecipitationsStruct {

--- a/TESReloaded/Core/ShadowManager.h
+++ b/TESReloaded/Core/ShadowManager.h
@@ -31,6 +31,7 @@ public:
 	void					RenderGeometry(NiGeometry* Geo);
 	void					Render(NiGeometry* Geo);
 	void					RenderShadowMap(ShadowMapTypeEnum ShadowMapType, SettingsShadowStruct::ExteriorsStruct* ShadowsExteriors, D3DXVECTOR3* At, D3DXVECTOR4* SunDir);
+	void					RenderExteriorCell(TESObjectCELL* Cell, SettingsShadowStruct::ExteriorsStruct* ShadowsExteriors, ShadowMapTypeEnum ShadowMapType);
 	void					RenderShadowCubeMap(NiPointLight** Lights, int LightIndex, SettingsShadowStruct::InteriorsStruct* ShadowsInteriors);
 	void					RenderShadowMaps();
 	void					CalculateBlend(NiPointLight** Lights, int LightIndex);

--- a/TESReloaded/Core/TextureManager.h
+++ b/TESReloaded/Core/TextureManager.h
@@ -1,6 +1,7 @@
 #pragma once
 #define SamplerStatesMax 12
 #define ShadowCubeMapsMax 4
+#define TrackedLightsMax 8
 
 class TextureRecord {
 public:

--- a/TESReloaded/Framework/NewVegas/GameNi.h
+++ b/TESReloaded/Framework/NewVegas/GameNi.h
@@ -589,9 +589,9 @@ assert(sizeof(NiLight) == 0xF0);
 
 class NiPointLight : public NiLight {
 public:
-	float			attenuation1;		// F0
-	float			attenuation2;		// F4
-	float			attenuation3;		// F8
+	float			Atten0;		// F0
+	float			Atten1;		// F4
+	float			Atten2;		// F8
 };
 assert(sizeof(NiPointLight) == 0xFC);
 


### PR DESCRIPTION
PR builds on the commits from PR #81.

This implements the tracking of 8 lights for shadow attenuation based on distance to lights.
This also fixes an issue where interior cells with a "exterior" flag were not properly recognised.

