### PR TITLE
fix water reflection height

### DIFF
--- a/TESReloaded/Core/SettingManager.cpp
+++ b/TESReloaded/Core/SettingManager.cpp
@@ -134,7 +134,8 @@ void SettingManager::Configuration::FillSections(StringList* Sections, const cha
 				Sections->push_back(SectionName);
 			InnerSectionPosition = GoToSection(SectionName, InnerSectionPosition.Start);
 			SectionPositionStart = InnerSectionPosition.End + 1;
-		}			Logger::Log("%0X", KeyPositionEnd);
+		}			
+
 
 		std::sort(Sections->begin(), Sections->end());
 	}

--- a/TESReloaded/Framework/NewVegas/Game.h
+++ b/TESReloaded/Framework/NewVegas/Game.h
@@ -4217,7 +4217,7 @@ struct WaterGroup
 
 class WaterManager {
 public:
-	UInt32				unk00;					// 000
+	UInt32 numWaterGroups;					// 000
 	UInt32				unk04;					// 004
 	UInt32				unk08;					// 008
 	UInt32				unk0C;					// 00C
@@ -4233,7 +4233,7 @@ public:
 	UInt8				unk34;					// 034
 	UInt8				pad34[3];
 	float				unk38;					// 038
-	DList<WaterGroup>	unk3C;					// 03C
+	DList<WaterGroup>	waterGroups;			// 03C
 	WaterGroup			*waterLOD; 				// 048
 	NiTMap<TESObjectREFR*, TESObjectREFR*>		unkReflectionExplosion;	// 04C Seems to be used only under a bReflectExplosions = 1 condition
 	NiTMap<TESObjectREFR*, TESObjectREFR*>		unk5C;	// 05C


### PR DESCRIPTION
fixes reflection heights for multiple water heights per cell by choosing the closest and most in front plane.

the watermanager structure seems different in Oblivion, so not sure how to fix it for both games, or if it's even needed?


![20230111 22 10 47](https://user-images.githubusercontent.com/5107178/211921404-94a109b7-1e3b-450a-ab32-f901672535d6.jpg)
![20230111 22 11 06](https://user-images.githubusercontent.com/5107178/211921411-aadb2bde-bb4e-4ab1-a9b7-d3955a836f77.jpg)
![20230111 22 14 56](https://user-images.githubusercontent.com/5107178/211921414-51ba9fa6-f76d-4e10-b641-72979392a44c.jpg)
![20230111 22 16 17](https://user-images.githubusercontent.com/5107178/211921415-d2664e46-f924-476f-bdd3-95a27bdb6ee8.jpg)
![20230111 22 18 21](https://user-images.githubusercontent.com/5107178/211921417-2ddd805d-718a-4242-a571-69cc2152bb45.jpg)
